### PR TITLE
Fix typos in simulator

### DIFF
--- a/config/vehicleModel.yaml
+++ b/config/vehicleModel.yaml
@@ -20,7 +20,7 @@ vehicle_model:
     wheelRadius: 0.206
     gearRatio: 12.23
     innerSteeringRatio: 0.255625
-    outerSteeringRaito: 0.20375
+    outerSteeringRatio: 0.20375
     nominalVoltageTS: 550.0
     powerGroundForce: 700.0
     powertrainEfficiency: 0.95

--- a/src/VehicleModel/VehicleModelBicycle.cpp
+++ b/src/VehicleModel/VehicleModelBicycle.cpp
@@ -41,7 +41,7 @@ public:
         configModel.getElement<double>(&this->wheelRadius, "wheelRadius");
         configModel.getElement<double>(&this->gearRatio, "gearRatio");
         configModel.getElement<double>(&this->innerSteeringRatio, "innerSteeringRatio");
-        configModel.getElement<double>(&this->innerSteeringRatio, "innerSteeringRatio");
+        configModel.getElement<double>(&this->outerSteeringRatio, "outerSteeringRatio");
         configModel.getElement<double>(&this->nominalVoltageTS, "nominalVoltageTS");
         configModel.getElement<double>(&this->powerGroundForce, "powerGroundForce");
         configModel.getElement<double>(&this->powertrainEfficiency, "powertrainEfficiency");

--- a/src/pacsim_main.cpp
+++ b/src/pacsim_main.cpp
@@ -515,7 +515,7 @@ void initSensors()
     auto frontSteeringConfig = sensorsConfig.getElement("steering_front");
     steeringSensorFront->readConfig(frontSteeringConfig);
     steeringSensorRear = std::make_shared<ScalarValueSensor>(200.0, 0.005);
-    auto rearSteeringConfig = sensorsConfig.getElement("steering_front");
+    auto rearSteeringConfig = sensorsConfig.getElement("steering_rear");
     steeringSensorRear->readConfig(rearSteeringConfig);
     auto wheelSpeedConfig = sensorsConfig.getElement("wheelspeeds");
     wheelspeedSensor = std::make_shared<WheelsSensor>(200.0, 0.005);


### PR DESCRIPTION
Found two typos

'outerSteeringRaito' in config
Read 'steering_front' in config for steeringSensorRear